### PR TITLE
remove gdata dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Depends:
     R (>= 2.10)
 Imports:
     readr,
-    gdata,
     dplyr,
     tibble,
     purrr,


### PR DESCRIPTION
gdata is listed as a dependency in the DESCRIPTION file but does not seem to be used by any of the current functions. 

Removed gdata from the DESCRIPTION file. 