### PR TITLE
Fixed UK data download

### DIFF
--- a/R/get_uk_nhs_region_cases.R
+++ b/R/get_uk_nhs_region_cases.R
@@ -6,7 +6,7 @@
 #' @export
 #' @importFrom dplyr mutate select filter full_join arrange group_by ungroup n lag
 #' @importFrom readr read_csv
-#' @importFrom tidyr gather
+#' @importFrom tidyr gather drop_na
 #' @examples
 #' get_uk_nhs_region_cases
 #'
@@ -38,7 +38,11 @@ get_uk_nhs_region_cases <- function() {
     dplyr::mutate(date = stringr::str_replace_all(Date,pattern = "\\.",replacement = "/")) %>%
     dplyr::select(-Date) %>%
     tidyr::gather("UTLA","confirm",-date) %>%
-    dplyr::mutate(UTLA = stringr::str_replace_all(UTLA, "_", " ")) %>%
+    tidyr::drop_na(date, confirm) %>%
+    dplyr::mutate(UTLA = stringr::str_replace_all(UTLA, "_", " "),
+                  confirm = confirm %>%
+                    stringr::str_squish() %>%
+                    as.numeric) %>%
     dplyr::filter(UTLA %in% c("London","South East","South West","East of England","Midlands",
                               "North East and Yorkshire", "North West", "Ayrshire and Arran",
                               "Borders", "Dumfries and Gallow",

--- a/R/get_uk_nhs_region_cases.R
+++ b/R/get_uk_nhs_region_cases.R
@@ -7,6 +7,7 @@
 #' @importFrom dplyr mutate select filter full_join arrange group_by ungroup n lag
 #' @importFrom readr read_csv
 #' @importFrom tidyr gather drop_na
+#' @importFrom stringr str_squish
 #' @examples
 #' get_uk_nhs_region_cases
 #'


### PR DESCRIPTION
* Upstream whitespace has started to creep into the data source meaning that cases was detected as a character string.
      * Stripped out whitespace using `stringr`
      * Converted to numeric
      * Dropped missing numeric entries
* Also seeing missing dates and I am dropping. I may have missed a change in format here so could be dropping data accidentally. 


Checking unique dates (below) this looks like a real NA so safe to remove. 

```
 unique(cases$Date)
 [1] "07/03/2020" "08/03/2020" "09/03/2020" "10/03/2020" "11/03/2020" "12/03/2020" "13/03/2020" "14/03/2020"
 [9] "15/03/2020" "16/03/2020" "17/03/2020" "18/03/2020" "19/03/2020" "20/03/2020" "21/03/2020" "22/03/2020"
[17] "23/03/2020" "24/03/2020" "25/03/2020" "26/03/2020" "27/03/2020" "28/03/2020" "29/03/2020" "30/03/2020"
[25] "31/03/2020" "01/04/2020" "02/04/2020" NA   
```

**This is needed for gov forecasts tonight so could someone check asap and carefully :) as I may have goofed.**
