### PR TITLE
New data source for Germany

### DIFF
--- a/R/get_germany_regional_cases.R
+++ b/R/get_germany_regional_cases.R
@@ -9,7 +9,7 @@
 #' @importFrom memoise cache_filesystem memoise
 #' @importFrom dplyr select group_by mutate summarise
 #' @importFrom readr read_csv
-#' @importFrom lubridate ymd
+#' @importFrom lubridate ymd_hms
 #' @examples
 #'
 #'
@@ -56,7 +56,7 @@ get_germany_regional_cases <- function(geography = "states") {
       cases = AnzahlFall,
       deaths = AnzahlTodesfall
     ) %>%
-    dplyr::mutate(date = lubridate::ymd(date))
+    dplyr::mutate(date = lubridate::ymd_hms(date))
 
   germany_state <- germany %>%
     dplyr::group_by(state, date) %>%

--- a/R/get_germany_regional_cases.R
+++ b/R/get_germany_regional_cases.R
@@ -1,14 +1,15 @@
-#' Get German daily cases by Bundeslander
+#' Get German daily cases by Bundeslander or Landkreis
 #'
 #'
 #' @description Fetches COVID case counts by region in Germany.
-#' This data is sourced from the Robert Koch Institute, was collated by Jan-Philip Gehrcke (gh: jgehrcke), and is available at:
-#' https://github.com/jgehrcke/covid-19-germany-gae
-#' @return A dataframe of case counts in German regions
+#' This data is sourced from the Robert Koch Institute:
+#' https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0
+#' @return A dataframe of case and death counts in German regions
 #' @export
 #' @importFrom memoise cache_filesystem memoise
-#' @importFrom dplyr select group_by mutate ungroup n lag
-#' @importFrom tidyr gather
+#' @importFrom dplyr select group_by mutate summarise
+#' @importFrom readr read_csv
+#' @importFrom lubridate ymd
 #' @examples
 #'
 #'
@@ -24,57 +25,52 @@
 #'
 #'regions_with_data <- regions %>%
 #'   dplyr::left_join(data,
-#'                   by = c("iso_3166_2" = "region_code"))
+#'                   by = c("name" = "state"))
 #'
 #'ggplot2::ggplot(regions_with_data) +
 #'   ggplot2::geom_sf(ggplot2::aes(fill = cases))
 #'
 #'}
+#'
 
-get_germany_regional_cases <- function() {
+get_germany_regional_cases <- function(geography = "states") {
 
-  path <- "https://raw.githubusercontent.com/jgehrcke/covid-19-germany-gae/master/cases-rki-by-state.csv"
+  if(!geography %in% c("states", "districts")) {
+    stop('Please specify geography: "states" (Bundesland), "districts" (Landkreis). Default: "states".')
+  }
+
+  path <- "https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv"
 
   ## Set up cache
   ch <- memoise::cache_filesystem(".cache")
 
-
   mem_read <- memoise::memoise(readr::read_csv, cache = ch)
 
-  cases <- mem_read(file = path)
+  germany <- mem_read(file = path) %>%
+    dplyr::select(
+      state_id = IdBundesland,
+      state = Bundesland,
+      district_id = IdLandkreis,
+      district = Landkreis,
+      date = Meldedatum,
+      cases = AnzahlFall,
+      deaths = AnzahlTodesfall
+    ) %>%
+    dplyr::mutate(date = lubridate::ymd(date))
 
-  cases <- cases %>%
-    dplyr::select(-sum_cases) %>%
-    dplyr::rename(date = time_iso8601) %>%
-    tidyr::gather(key = "region_code", value = "total_cases", -date) %>%
-    dplyr::group_by(region_code) %>%
-    dplyr::mutate(
-      date = as.Date(date),
-      index = 1:dplyr::n(),
-      cases = total_cases - ifelse(index == 1, 0, dplyr::lag(total_cases))) %>%
-    dplyr::ungroup() %>%
-    dplyr::select(-index, -total_cases) %>%
-    ## Adjust negative cases by setting to 0
-    dplyr::mutate(cases = ifelse(cases < 0 , 0, cases),
-                  region = dplyr::recode(region_code,
-                                         "DE-BW" = "Baden-Wurttemberg",
-                                         "DE-BY" = "Bavaria",
-                                         "DE-BE" = "Berlin",
-                                         "DE-BB" = "Brandenburg",
-                                         "DE-HB" = "Bremen",
-                                         "DE-HH" = "Hamburg",
-                                         "DE-HE" = "Hesse",
-                                         "DE-NI" = "Lower Saxony",
-                                         "DE-MV" = "Mecklenburg-Vorpommern",
-                                         "DE-NW" = "North Rhine-Westphalia",
-                                         "DE-RP" = "Rhineland-Palatinate",
-                                         "DE-SL" = "Saarland",
-                                         "DE-SN" = "Saxony",
-                                         "DE-ST" = "Saxony-Anhalt",
-                                         "DE-SH" = "Schleswig-Holstein",
-                                         "DE-TH" = "Thuringia"))
+  germany_state <- germany %>%
+    dplyr::group_by(state, date) %>%
+    dplyr::summarise(cases = sum(cases),
+                     deaths = sum(deaths))
+  germany_district <- germany %>%
+    dplyr::group_by(district, date) %>%
+    dplyr::summarise(cases = sum(cases),
+                     deaths = sum(deaths))
 
 
-
-  return(cases)
+  if (geography == "states"){
+    return(germany_state)
+  }else if (geography == "districts"){
+    return(germany_district)
+  }
 }


### PR DESCRIPTION
- Sourcing data for German regions directly from the Robert Koch Institute

- New option to specify admin units by Bundesland (states) or Landkreis (districts); default is "states", which is the same admin level as before

- Column name for this reflect the option (state or district), no longer "region"