### PR TITLE
New url for linelist

### DIFF
--- a/R/get_international_linelist.R
+++ b/R/get_international_linelist.R
@@ -34,7 +34,7 @@ get_international_linelist <- function(countries = NULL, cities = NULL, province
 
   ch <- memoise::cache_filesystem(".cache")
 
-  url <- "https://raw.githubusercontent.com/beoutbreakprepared/nCoV2019/master/latest_data/latestdata.csv"
+  url <- "https://raw.github.com/beoutbreakprepared/nCoV2019/master/latest_data/latestdata.tar.gz"
 
   mem_read <- memoise::memoise(readr::read_csv, cache = ch)
   linelist <- suppressWarnings(


### PR DESCRIPTION
Same source, new URL to download linelist from compressed csv ([linked](https://github.com/beoutbreakprepared/nCoV2019/blob/master/latest_data/latestdata.tar.gz))

Addresses issue #100 