### PR TITLE
Version bump

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: NCoVUtils
 Title: Data Extraction Tools for the Covid-19 Outbreak
-Version: 0.4.0
+Version: 0.6.0
 Authors@R: c(person(given = "Sam Abbott",
            role = c("aut", "cre"),
            email = "contact@samabbott.co.uk",


### PR DESCRIPTION
match the latest tagged version.
Ensure that people have the latest version - the change to get_ecdc_cases from 2018 to 2019 is causing bugs to pop up where some are running new and some are running old, all report 0.4.0. Possibly consider adding a min req to the description file in /covid to be more explicit and keep it up to date with the new versions of the libraries to try and prevent people having old dependencies (epiforecasts/covid-global#1) .